### PR TITLE
Add /webpack-dev-server to url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 npm start
 ```
 
-Visit `http://localhost:3000` in your browser, edit `src/purs/App.purs` and
+Visit `http://localhost:3000/webpack-dev-server` in your browser, edit `src/purs/App.purs` and
 watch the magic!
 
 ## Available tasks


### PR DESCRIPTION
opening the browser there shows a nicer environment with 'App ready' in
the header bar, and according to some issue (can't find it back atm) it
also helps when webpack does not want to reload (not to sure about
that).
