### PR TITLE
Add the connect-history-api-fallback middleware for the dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "bower": "^1.7.9",
+    "connect-history-api-fallback": "^1.2.0",
     "copy-webpack-plugin": "^2.1.1",
     "express": "^4.13.4",
     "html-webpack-plugin": "^2.15.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,7 @@ if (require.main === module) {
   // webpack-dev-server, because webpack-hot-middleware provides more reliable
   // HMR behavior, and an in-browser overlay that displays build errors
   app
+    .use(require('connect-history-api-fallback')())
     .use(require("webpack-dev-middleware")(compiler, {
       publicPath: config.output.publicPath,
       stats: {


### PR DESCRIPTION
This middleware automatically redirects HTTP requests to non-file paths to the index.html file, which allows the client-side router to handle routing those requests instead of simply getting a 404 from the server.
