### PR TITLE
Fix deprecated webpack module

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ var config = {
       filename: 'index.html'
     }),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
   ],
   resolveLoader: {
     modules: [


### PR DESCRIPTION
webpack deprecated `NoErrorsPlugin` in favour of more expressively named `NoEmitOnErrorsPlugin`: https://github.com/webpack/webpack/pull/3570